### PR TITLE
removido dependencia mpociot/laravel-apidoc-generator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
     "spatie/laravel-activitylog": "^3.14",
     "barryvdh/laravel-ide-helper": "^2.6",
     "krlove/eloquent-model-generator": "^1.3",
-    "mpociot/laravel-apidoc-generator": "^4.4",
     "tymon/jwt-auth": "^1.0"
   },
   "autoload": {


### PR DESCRIPTION
Removido dependência mpociot/laravel-apidoc-generator.

Foi escolhido deixar ser adquirida manualmente  